### PR TITLE
Add namespace prefix to globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,5 @@ Just paste the package's contents into into your .vim directory.
 You can customize the maximum number of columns visible by putting this in your
 .vimrc (default is 3):
 
-    let g:max_columns = 4
+    let g:columntags_max_columns = 4
+

--- a/plugin/columntags.vim
+++ b/plugin/columntags.vim
@@ -4,13 +4,13 @@
 " License: This file is placed in the public domain
 " Version: 0.1
 
-if exists("g:loaded_columntags")
+if exists("g:columntags_loaded")
     finish
 endif
-let g:loaded_columntags = 1
+let g:columntags_loaded = 1
 
 " Globals
-let g:max_columns = 3
+let g:columntags_max_columns = 3
 
 " Stash
 " camelCase for staticmethods, underscore for instance methods


### PR DESCRIPTION
- In order to prevent any future name clashes, adds a 'columntags' prefix to the `max_columns` global.
- Also updates the `loaded_columntags` global to follow suit.

Fixes #2
